### PR TITLE
adapted check to european naming convention

### DIFF
--- a/code/validation/validate_filenames.py
+++ b/code/validation/validate_filenames.py
@@ -11,7 +11,7 @@ for folder in folders:
     file_names = [f for f in folder.iterdir() if f.name.endswith('.csv')]
 
     # remove ending '.csv', remove date, split between country and model name
-    model_names = [f.stem[11:].split('-', maxsplit=1)[-1] for f in file_names]
+    model_names = [f.stem[11:] for f in file_names]
 
     # for each file check if the model name equals the folder name
     for i, m in enumerate(model_names):


### PR DESCRIPTION
There is no need to handle countries in the names of forecast files. 
After cutting of the date (first 11 characters) we can just compare the folder name to the file name