### PR TITLE
Fix #70: Error if forecast_date <5 days from target_end_date

### DIFF
--- a/code/validation/covid19.py
+++ b/code/validation/covid19.py
@@ -114,7 +114,7 @@ def covid19_row_validator(column_index_dict, row, codes):
 
     # 3.2 Expect a minimum 5 days between forecast_date and target_end_date
     date_diff = target_end_date - forecast_date
-    if date_diff < 5:
+    if date_diff < datetime.timedelta(days=5):
         error_messages.append(f"Error > target_end_date was <5 days after forecast_date: {target_end_date}. row={row}")
         return error_messages  # terminate - depends on valid target_end_date
     


### PR DESCRIPTION
Adds extra check to return error and terminate validation if `forecast_date` is too close in time (<5 calendar days) to `target_end_date`. Should solve the problem of invalid submissions with a forecast date Tuesday or later which have a "1 wk ahead" target for that same week's Saturday. Fixes #70