### PR TITLE
Add validation check: values are >= 0

### DIFF
--- a/code/validation/covid19.py
+++ b/code/validation/covid19.py
@@ -62,6 +62,7 @@ def covid19_row_validator(column_index_dict, row, codes):
     """
     Does COVID19-specific row validation. Notes:
     - Checks in order:
+    0. value
     1. location
     2. quantiles
     3. forecast_date and target_end_date (terminates if invalid)
@@ -83,7 +84,7 @@ def covid19_row_validator(column_index_dict, row, codes):
     
     # 0. Validate forecast value
     value = row[column_index_dict['value']]
-    if value < 0:
+    if float(value) < 0:
         error_messages.append(f"Error > negative value in forecast: {value!r}. row={row}")
 
     # 1. validate location (ISO-2 code)

--- a/code/validation/covid19.py
+++ b/code/validation/covid19.py
@@ -80,6 +80,11 @@ def covid19_row_validator(column_index_dict, row, codes):
     from cdc_io import _parse_date  # avoid circular imports
 
     error_messages = []  # returned value. filled next
+    
+    # 0. Validate forecast value
+    value = row[column_index_dict['value']]
+    if value < 0:
+        error_messages.append(f"Error > negative value in forecast: {value!r}. row={row}")
 
     # 1. validate location (ISO-2 code)
     location = row[column_index_dict['location']]


### PR DESCRIPTION
Checks values are >= 0. 

Currently failing forecasts will always cause all checks to fail unless we do something about them. I think these are the options but none ideal so glad for other ideas:
- remove the entire csv
- remove only the quantiles with negative values
- replace negative values with 0
- keep as is; make the validation check conditional on a `forecast_date` later than 2021-03-08


Files failing on this check, in `data-processed` :
```
itwm-dSEIR/2021-02-22-itwm-dSEIR.csv
itwm-dSEIR/2021-02-15-itwm-dSEIR.csv
itwm-dSEIR/2021-03-01-itwm-dSEIR.csv
itwm-dSEIR/2021-03-08-itwm-dSEIR.csv
epiforecasts-EpiExpert/2021-03-08-epiforecasts-EpiExpert.csv
Karlen-pypm/2021-02-28-Karlen-pypm.csv
Karlen-pypm/2021-03-07-Karlen-pypm.csv
EuroCOVIDhub-ensemble/2021-03-08-EuroCOVIDhub-ensemble.csv
```