### PR TITLE
Ensemble fix: manual exclusions by `forecast_date`

### DIFF
--- a/code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R
+++ b/code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R
@@ -18,7 +18,7 @@ forecast_date <- floor_date(today(), "week", 1)
 # Get model names for manual exclusion
 exclude_models <-
   vroom(here("code", "ensemble", "EuroCOVIDhub", "manual-exclusions.csv")) %>%
-  filter(forecast_date == forecast_date) %>%
+  filter(forecast_date == !!forecast_date) %>%
   pull(model)
 
 # Run weekly automated ensemble -----------------------------------------

--- a/code/ensemble/utils/run-ensemble.R
+++ b/code/ensemble/utils/run-ensemble.R
@@ -10,7 +10,8 @@
 # Params:
 # method : character L1 : name of an ensembling method
 # forecast_date : date or character
-# exclude models : character : names of team-models to exclude by forecast_date
+# exclude models : character or data frame: names of team-models to exclude 
+#   (if data.frame, by forecast_date)
 # return_criteria : logical : whether to return a model/inclusion criteria grid
 #  as well as the ensemble forecast (default TRUE)
 # 
@@ -35,12 +36,24 @@ run_ensemble <- function(method,
                          exclude_models = NULL,
                          return_criteria = TRUE) {
 
+  if (missing(method)) {
+    method <- readLines(here("code", "ensemble", "EuroCOVIDhub",  
+                             "current-method.txt"))
+  }
+  
   # determine forecast dates matching the forecast date
   forecast_dates <- seq.Date(from = forecast_date,
                              by = -1,
                              length.out = 6)
 
-  # Load forecasts and save criteria --------------------------------------------
+  # If manual exclusion is csv, convert to vector
+  if ("data.frame" %in% class(exclude_models)) {
+    exclude_models <- exclude_models %>%
+      filter(forecast_date == !!forecast_date) %>%
+      pull(model)
+  }
+  
+  # Load forecasts and save criteria ------------------------------------------
   # Get all forecasts
   all_forecasts <- load_forecasts(source = "local_hub_repo",
                               hub_repo_path = here(),

--- a/code/ensemble/utils/run-ensemble.R
+++ b/code/ensemble/utils/run-ensemble.R
@@ -10,8 +10,7 @@
 # Params:
 # method : character L1 : name of an ensembling method
 # forecast_date : date or character
-# exclude models : character or data frame: names of team-models to exclude 
-#   (if data.frame, by forecast_date)
+# exclude models : character : names of team-models to exclude by forecast_date
 # return_criteria : logical : whether to return a model/inclusion criteria grid
 #  as well as the ensemble forecast (default TRUE)
 # 
@@ -36,24 +35,12 @@ run_ensemble <- function(method,
                          exclude_models = NULL,
                          return_criteria = TRUE) {
 
-  if (missing(method)) {
-    method <- readLines(here("code", "ensemble", "EuroCOVIDhub",  
-                             "current-method.txt"))
-  }
-  
   # determine forecast dates matching the forecast date
   forecast_dates <- seq.Date(from = forecast_date,
                              by = -1,
                              length.out = 6)
 
-  # If manual exclusion is csv, convert to vector
-  if ("data.frame" %in% class(exclude_models)) {
-    exclude_models <- exclude_models %>%
-      filter(forecast_date == !!forecast_date) %>%
-      pull(model)
-  }
-  
-  # Load forecasts and save criteria ------------------------------------------
+  # Load forecasts and save criteria --------------------------------------------
   # Get all forecasts
   all_forecasts <- load_forecasts(source = "local_hub_repo",
                               hub_repo_path = here(),


### PR DESCRIPTION
Fixes a bug in `create-weekly-ensemble.R`.

- The weekly `forecast_date` was not properly used in filtering manual model exclusions (e.g. where a model was submitted late and should be excluded for one week only). 
- This meant that any model in the `manual-exclusions.csv` was excluded every week. 
- For weeks since 2021-04-05, two models have been excluded which should have been included in the ensemble. This affects past weekly ensemble forecasts for Germany and Poland (1-4 week cases and deaths).

Past ensembles will be updated with correct models in separate PR.