### PR TITLE
Exclude data anomalies from evaluation

### DIFF
--- a/code/evaluation/score_models.r
+++ b/code/evaluation/score_models.r
@@ -112,10 +112,19 @@ forecasts <- forecasts[forecast_date >= "2021-03-08"]
 setnames(forecasts, old = c("value"), new = c("prediction"))
 
 ## load truth data -------------------------------------------------------------
-truth <- map_dfr(.x = c("inc case", "inc death"),
+raw_truth <- map_dfr(.x = c("inc case", "inc death"),
                  .f = ~ load_truth(truth_source = "JHU",
                                    target_variable = .x,
                                    hub = "ECDC"))
+# get anomalies
+anomalies <- read_csv(here("data-truth", "anomalies", "anomalies.csv"))
+truth <- left_join(raw_truth, anomalies,
+                            by = c("target_variable",
+                                   "location", "location_name",
+                                   "target_end_date")) %>%
+  filter(is.na(anomaly)) %>%
+  mutate(anomaly = NULL)
+
 setDT(truth)
 truth[, model := NULL]
 setnames(truth, old = c("value"),

--- a/code/evaluation/score_models.r
+++ b/code/evaluation/score_models.r
@@ -123,7 +123,7 @@ truth <- left_join(raw_truth, anomalies,
                                    "location", "location_name",
                                    "target_end_date")) %>%
   filter(is.na(anomaly)) %>%
-  mutate(anomaly = NULL)
+  select(-anomaly)
 
 setDT(truth)
 truth[, model := NULL]

--- a/code/reports/compile-evaluation-reports.r
+++ b/code/reports/compile-evaluation-reports.r
@@ -31,10 +31,19 @@ forecasts <- forecasts[forecast_date <= last_forecast_date]
 setnames(forecasts, old = c("value"), new = c("prediction"))
 
 ## load truth data -------------------------------------------------------------
-truth <- map_dfr(.x = c("inc case", "inc death"),
-                 .f = ~ load_truth(truth_source = "JHU",
-                                   target_variable = .x,
-                                   hub = "ECDC"))
+raw_truth <- map_dfr(.x = c("inc case", "inc death"),
+                     .f = ~ load_truth(truth_source = "JHU",
+                                       target_variable = .x,
+                                       hub = "ECDC"))
+# get anomalies
+anomalies <- read_csv(here("data-truth", "anomalies", "anomalies.csv"))
+truth <- left_join(raw_truth, anomalies,
+                   by = c("target_variable",
+                          "location", "location_name",
+                          "target_end_date")) %>%
+  filter(is.na(anomaly)) %>%
+  select(-anomaly)
+
 setDT(truth)
 truth[, model := NULL]
 truth <- truth[target_end_date <= report_date]

--- a/code/reports/ensemble/ensemble-report.Rmd
+++ b/code/reports/ensemble/ensemble-report.Rmd
@@ -49,10 +49,19 @@ forecasts <- forecasts[forecast_date <= as.Date(params$report_date)]
 setnames(forecasts, old = c("value"), new = c("prediction"))
 
 # load truth data --------------------------------------------------------------
-truth <- map_dfr(.x = c("inc case", "inc death"),
+raw_truth <- map_dfr(.x = c("inc case", "inc death"),
                  .f = ~ load_truth(truth_source = "JHU",
                                    target_variable = .x,
-                                   hub = "ECDC")) 
+                                   hub = "ECDC"))
+# get anomalies
+anomalies <- read_csv(here("data-truth", "anomalies", "anomalies.csv"))
+truth <- left_join(raw_truth, anomalies,
+                            by = c("target_variable",
+                                   "location", "location_name",
+                                   "target_end_date")) %>%
+  filter(is.na(anomaly)) %>%
+  select(-anomaly)
+
 setDT(truth)
 truth[, model := NULL]
 truth <- truth[target_end_date <= as.Date(params$report_date)]

--- a/data-truth/anomalies/anomalies.csv
+++ b/data-truth/anomalies/anomalies.csv
@@ -1,6 +1,7 @@
-forecast_date,target_variable,location,location_name,problem
-2021-05-24,case,FR,France,Removed double counted cases
-2021-05-24,case,IE,Ireland,No data reported
-2021-05-24,case,IE,Ireland,No data reported
-2021-05-31,death,IE,Ireland,No data reported
-2021-05-31,death,IE,Ireland,No data reported
+target_end_date,target_variable,location,location_name,anomaly
+2021-03-06,inc case,ES,Spain,Negative case reporting
+2021-05-22,inc case,FR,France,Removed double counting
+2021-05-22,inc case,IE,Ireland,No data reported
+2021-05-22,inc death,IE,Ireland,No data reported
+2021-05-29,inc case,IE,Ireland,No data reported
+2021-05-29,inc death,IE,Ireland,No data reported

--- a/data-truth/anomalies/anomalies.csv
+++ b/data-truth/anomalies/anomalies.csv
@@ -1,6 +1,6 @@
-forecast_date	target_variable	location	location_name	problem
-2021-05-24	case	FR	France	Removed double counted cases
-2021-05-24	case	IE	Ireland	No data reported
-2021-05-24	case	IE	Ireland	No data reported
-2021-05-31	death	IE	Ireland	No data reported
-2021-05-31	death	IE	Ireland	No data reported
+forecast_date,target_variable,location,location_name,problem
+2021-05-24,case,FR,France,Removed double counted cases
+2021-05-24,case,IE,Ireland,No data reported
+2021-05-24,case,IE,Ireland,No data reported
+2021-05-31,death,IE,Ireland,No data reported
+2021-05-31,death,IE,Ireland,No data reported

--- a/data-truth/anomalies/anomalies.csv
+++ b/data-truth/anomalies/anomalies.csv
@@ -1,0 +1,6 @@
+forecast_date	target_variable	location	location_name	problem
+2021-05-24	case	FR	France	Removed double counted cases
+2021-05-24	case	IE	Ireland	No data reported
+2021-05-24	case	IE	Ireland	No data reported
+2021-05-31	death	IE	Ireland	No data reported
+2021-05-31	death	IE	Ireland	No data reported

--- a/data-truth/anomalies/create-anomalies.R
+++ b/data-truth/anomalies/create-anomalies.R
@@ -14,4 +14,5 @@ anomalies <- tribble(
 )
 
 vroom_write(anomalies,
-            here("data-truth", "anomalies", "anomalies.csv"))
+            here("data-truth", "anomalies", "anomalies.csv"),
+            delim = ",")

--- a/data-truth/anomalies/create-anomalies.R
+++ b/data-truth/anomalies/create-anomalies.R
@@ -5,13 +5,15 @@ library(dplyr)
 library(tibble)
 
 anomalies <- tribble(
-  ~forecast_date, ~target_variable, ~location, ~location_name, ~problem,
-  "2021-05-24", "case", "FR", "France", "Removed double counting",
-  "2021-05-24", "case", "IE", "Ireland", "No data reported",
-  "2021-05-24", "death", "IE", "Ireland", "No data reported",
-  "2021-05-31", "case", "IE", "Ireland", "No data reported",
-  "2021-05-31", "death", "IE", "Ireland", "No data reported"
-)
+  ~target_end_date, ~target_variable, ~location, ~location_name, ~anomaly,
+  "2021-03-06", "inc case", "ES", "Spain", "Negative case reporting",
+  "2021-05-22", "inc case", "FR", "France", "Removed double counting",
+  "2021-05-22", "inc case", "IE", "Ireland", "No data reported",
+  "2021-05-22", "inc death", "IE", "Ireland", "No data reported",
+  "2021-05-29", "inc case", "IE", "Ireland", "No data reported",
+  "2021-05-29", "inc death", "IE", "Ireland", "No data reported"
+) %>%
+  mutate(target_end_date = as.Date(target_end_date))
 
 vroom_write(anomalies,
             here("data-truth", "anomalies", "anomalies.csv"),

--- a/data-truth/anomalies/create-anomalies.R
+++ b/data-truth/anomalies/create-anomalies.R
@@ -1,0 +1,17 @@
+# Create csv with data anomalies
+# 2021-06-01 placeholder before implementing automated detection
+library(here)
+library(dplyr)
+library(tibble)
+
+anomalies <- tribble(
+  ~forecast_date, ~target_variable, ~location, ~location_name, ~problem,
+  "2021-05-24", "case", "FR", "France", "Removed double counting",
+  "2021-05-24", "case", "IE", "Ireland", "No data reported",
+  "2021-05-24", "death", "IE", "Ireland", "No data reported",
+  "2021-05-31", "case", "IE", "Ireland", "No data reported",
+  "2021-05-31", "death", "IE", "Ireland", "No data reported"
+)
+
+vroom_write(anomalies,
+            here("data-truth", "anomalies", "anomalies.csv"))


### PR DESCRIPTION
This PR adds a csv noting which locations/target variables have anomalies affecting the weekly evaluation.

These values are excluded from evaluation.

This is really a placeholder before implementing an automated anomaly detection process.