### PR TITLE
Try to speed up package installation in R-based GH actions

### DIFF
--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -8,6 +8,8 @@ jobs:
   get_ecdc:
     runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@master
     - uses: r-lib/actions/setup-r@v1
@@ -20,7 +22,7 @@ jobs:
 
     - name: ECDC Truth
       run: Rscript 'code/auto_download/ecdc_download.r'
-        
+
     - name: Commit files
       env:
         AUTH: ${{ secrets.GITHUBTOKEN }}
@@ -29,5 +31,5 @@ jobs:
         git config user.name "GitHub Action - ECDC"
         git add --all
         git commit -m "ECDC - daily"
-        git push 
+        git push
         echo "pushed to github"

--- a/.github/workflows/JHU.yml
+++ b/.github/workflows/JHU.yml
@@ -3,15 +3,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * *"
-  
+
 jobs:
   get_jhu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
     steps:
     - uses: actions/checkout@master
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
 
     - name: Setup Python
       uses: actions/setup-python@v2
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install requirenments
       run: pip3 install pandas
-    
+
     - name: JHU Truth
       run: python3 ./code/auto_download/jhu_download.py
 
@@ -32,5 +32,5 @@ jobs:
         git config user.name "GitHub Action - JHU"
         git add --all
         git commit -m "JHU - daily"
-        git push 
+        git push
         echo "pushed to github"

--- a/.github/workflows/JHU.yml
+++ b/.github/workflows/JHU.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install requirenments
+    - name: Install requirements
       run: pip3 install pandas
 
     - name: JHU Truth

--- a/.github/workflows/LANL.yml
+++ b/.github/workflows/LANL.yml
@@ -8,6 +8,8 @@ jobs:
   get_lanl:
     runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@master
     - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/check-truth.yml
+++ b/.github/workflows/check-truth.yml
@@ -26,11 +26,11 @@ jobs:
         python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
-    - name: Install python requirenments
+    - name: Install python requirements
       run: |
         pip3 install -r github-actions/pr_requirements.txt
 
-    - name: Install R requirenments
+    - name: Install R requirements
       run: |
         sudo apt-get install pandoc libcurl4-openssl-dev
         Rscript -e 'install.packages(c("gh", "dplyr", "stringr", "here", "knitr", "rmarkdown", "readr", "tibble", "countrycode"))'

--- a/.github/workflows/check-truth.yml
+++ b/.github/workflows/check-truth.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@master
       with:
@@ -49,5 +51,5 @@ jobs:
         git config user.name "GitHub Action - check truth"
         git add --all
         git commit -m "Check truth data"
-        git push 
+        git push
         echo "pushed to github"

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -8,6 +8,8 @@ jobs:
   ensemble:
     runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@master
     - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Install R dependencies
       run: |
-       Rscript -e 'install.packages(c("here", "vroom", "dplyr", "tibble", "lubridate", "devtools"))'
-       Rscript -e 'devtools::install_github("reichlab/covidHubUtils")'
+       Rscript -e 'install.packages(c("here", "vroom", "dplyr", "tibble", "lubridate", "remotes"))'
+       Rscript -e 'remotes::install_github("reichlab/covidHubUtils")'
 
     - name: Create ensembles
       run: Rscript 'code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R'

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -8,6 +8,8 @@ jobs:
   ensemble:
     runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@master
     - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Install R dependencies
       run: |
-       Rscript -e 'install.packages(c("here", "dplyr", "data.table", "lubridate", "devtools", "tidyr", "purrr", "readr"))'
-       Rscript -e 'devtools::install_github("reichlab/covidHubUtils")'
+       Rscript -e 'install.packages(c("here", "dplyr", "data.table", "lubridate", "remotes", "tidyr", "purrr", "readr"))'
+       Rscript -e 'remotes::install_github("reichlab/covidHubUtils")'
        Rscript -e 'remotes::install_github("epiforecasts/scoringutils")'
 
     - name: Score forecasts

--- a/.github/workflows/reports-ensemble.yml
+++ b/.github/workflows/reports-ensemble.yml
@@ -7,6 +7,8 @@ jobs:
   ensemble_report:
     runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@v2
     - uses: r-lib/actions/setup-r@v1
@@ -22,7 +24,7 @@ jobs:
 
     - name: Create ensemble reports
       run: Rscript 'code/reports/compile-ensemble-report.r'
-        
+
     - name: Push to web site
       uses: dmnemec/copy_file_to_another_repo_action@main
       env:

--- a/.github/workflows/reports-eval.yml
+++ b/.github/workflows/reports-eval.yml
@@ -7,6 +7,8 @@ jobs:
   evaluation_reports:
     runs-on: ubuntu-20.04
     if: github.repository == 'epiforecasts/covid19-forecast-hub-europe'
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
     steps:
     - uses: actions/checkout@v2
     - uses: r-lib/actions/setup-r@v1
@@ -22,7 +24,7 @@ jobs:
 
     - name: Create evaluation reports
       run: Rscript 'code/reports/compile-evaluation-reports.r'
-        
+
     - name: Push to web site
       uses: dmnemec/copy_file_to_another_repo_action@main
       env:


### PR DESCRIPTION
This is a first attempt at speeding up package installation in R-based GH actions. I might have to revisit it because:

- I've had some troubles getting RStudio Package Manager to actually deliver binaries on Linux in the past
- The achieved speed up might not be sufficient. In that case, I can add a caching step to avoid re-downloading / re-installing these packages each time