### PR TITLE
Create actions README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,19 +1,19 @@
 ## Scheduled workflows
 
-| Action name                                                                                                                            | Language   | Scheduled at                                                   | Function                     |
-|----------------------------------------------------------------------------------------------------------------------------------------|------------|----------------------------------------------------------------|------------------------------|
-| [`ECDC.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/ECDC.yml)                         | R          | [12:00 every Thursday](https://crontab.guru/#0_12_*_*_4)       | Get recorded cases from ECDC |
-| [`JHU.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/JHU.yml)                           | Python     | [7:00 every day](https://crontab.guru/#0_7_*_*_*)              | Get recorded cases from JHU  |
-| [`LANL.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/LANL.yml)                         | R          | [0:00 every day](https://crontab.guru/#0_0_*_*_*)              |                              |
-| [`check-truth.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/check-truth.yml)           | Python & R | [13:00 every day](https://crontab.guru/#0_13_*_*_*)            |                              |
-| [`ensemble.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/ensemble.yml)                 | R          | [10:15 every Tuesday](https://crontab.guru/#15_10_*_*_2)       | Create weekly ensemble       |
-| [`evaluation.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/evaluation.yml)             | R          | [10:00 every Sunday](https://crontab.guru/#0_10_*_*_0)         | Compute forecast scores      |
-| [`reports-ensemble.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/reports-ensemble.yml) | R          | [10:45 every Tuesday](https://crontab.guru/#45_10_*_*_2)       | Compile ensemble report      |
-| [`reports-eval.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/reports-eval.yml)         | R          | [9:00 every Sunday](https://crontab.guru/#0_9_*_*_0)           | Compile evaluation reports   |
-| [`visualisation.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/visualisation.yml)       | Python     | [8:00 and 11:00 every day](https://crontab.guru/#0_8,11_*_*_*) |                              |
+| Action name                                    | Language   | Scheduled at                                                   | Function                     |
+|------------------------------------------------|------------|----------------------------------------------------------------|------------------------------|
+| [`ECDC.yml`](ECDC.yml)                         | R          | [12:00 every Thursday](https://crontab.guru/#0_12_*_*_4)       | Get recorded cases from ECDC |
+| [`JHU.yml`](JHU.yml)                           | Python     | [7:00 every day](https://crontab.guru/#0_7_*_*_*)              | Get recorded cases from JHU  |
+| [`LANL.yml`](LANL.yml)                         | R          | [0:00 every day](https://crontab.guru/#0_0_*_*_*)              |                              |
+| [`check-truth.yml`](check-truth.yml)           | Python & R | [13:00 every day](https://crontab.guru/#0_13_*_*_*)            |                              |
+| [`ensemble.yml`](ensemble.yml)                 | R          | [10:15 every Tuesday](https://crontab.guru/#15_10_*_*_2)       | Create weekly ensemble       |
+| [`evaluation.yml`](evaluation.yml)             | R          | [10:00 every Sunday](https://crontab.guru/#0_10_*_*_0)         | Compute forecast scores      |
+| [`reports-ensemble.yml`](reports-ensemble.yml) | R          | [10:45 every Tuesday](https://crontab.guru/#45_10_*_*_2)       | Compile ensemble report      |
+| [`reports-eval.yml`](reports-eval.yml)         | R          | [9:00 every Sunday](https://crontab.guru/#0_9_*_*_0)           | Compile evaluation reports   |
+| [`visualisation.yml`](visualisation.yml)       | Python     | [8:00 and 11:00 every day](https://crontab.guru/#0_8,11_*_*_*) |                              |
 
 ## Submission checks
 
-| Action name                                                                                                                    | Language |
-|--------------------------------------------------------------------------------------------------------------------------------|----------|
-| [`ValidationV2.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/ValidationV2.yml) | Python   |
+| Action name                            | Language |
+|----------------------------------------|----------|
+| [`ValidationV2.yml`](ValidationV2.yml) | Python   |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,19 @@
+## Scheduled workflows
+
+| Action name                                                                                                                            | Language   | Scheduled at                                                   | Function                     |
+|----------------------------------------------------------------------------------------------------------------------------------------|------------|----------------------------------------------------------------|------------------------------|
+| [`ECDC.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/ECDC.yml)                         | R          | [12:00 every Thursday](https://crontab.guru/#0_12_*_*_4)       | Get recorded cases from ECDC |
+| [`JHU.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/JHU.yml)                           | Python     | [7:00 every day](https://crontab.guru/#0_7_*_*_*)              | Get recorded cases from JHU  |
+| [`LANL.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/LANL.yml)                         | R          | [0:00 every day](https://crontab.guru/#0_0_*_*_*)              |                              |
+| [`check-truth.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/check-truth.yml)           | Python & R | [13:00 every day](https://crontab.guru/#0_13_*_*_*)            |                              |
+| [`ensemble.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/ensemble.yml)                 | R          | [10:15 every Tuesday](https://crontab.guru/#15_10_*_*_2)       | Create weekly ensemble       |
+| [`evaluation.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/evaluation.yml)             | R          | [10:00 every Sunday](https://crontab.guru/#0_10_*_*_0)         | Compute forecast scores      |
+| [`reports-ensemble.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/reports-ensemble.yml) | R          | [10:45 every Tuesday](https://crontab.guru/#45_10_*_*_2)       | Compile ensemble report      |
+| [`reports-eval.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/reports-eval.yml)         | R          | [9:00 every Sunday](https://crontab.guru/#0_9_*_*_0)           | Compile evaluation reports   |
+| [`visualisation.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/visualisation.yml)       | Python     | [8:00 and 11:00 every day](https://crontab.guru/#0_8,11_*_*_*) |                              |
+
+## Submission checks
+
+| Action name                                                                                                                    | Language |
+|--------------------------------------------------------------------------------------------------------------------------------|----------|
+| [`ValidationV2.yml`](https://github.com/epiforecasts/covid19-forecast-hub-europe/blob/main/.github/workflows/ValidationV2.yml) | Python   |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,16 +1,16 @@
 ## Scheduled workflows
 
-| Action name                                    | Language   | Scheduled at                                                   | Function                     |
-|------------------------------------------------|------------|----------------------------------------------------------------|------------------------------|
-| [`ECDC.yml`](ECDC.yml)                         | R          | [12:00 every Thursday](https://crontab.guru/#0_12_*_*_4)       | Get recorded cases from ECDC |
-| [`JHU.yml`](JHU.yml)                           | Python     | [7:00 every day](https://crontab.guru/#0_7_*_*_*)              | Get recorded cases from JHU  |
-| [`LANL.yml`](LANL.yml)                         | R          | [0:00 every day](https://crontab.guru/#0_0_*_*_*)              |                              |
-| [`check-truth.yml`](check-truth.yml)           | Python & R | [13:00 every day](https://crontab.guru/#0_13_*_*_*)            |                              |
-| [`ensemble.yml`](ensemble.yml)                 | R          | [10:15 every Tuesday](https://crontab.guru/#15_10_*_*_2)       | Create weekly ensemble       |
-| [`evaluation.yml`](evaluation.yml)             | R          | [10:00 every Sunday](https://crontab.guru/#0_10_*_*_0)         | Compute forecast scores      |
-| [`reports-ensemble.yml`](reports-ensemble.yml) | R          | [10:45 every Tuesday](https://crontab.guru/#45_10_*_*_2)       | Compile ensemble report      |
-| [`reports-eval.yml`](reports-eval.yml)         | R          | [9:00 every Sunday](https://crontab.guru/#0_9_*_*_0)           | Compile evaluation reports   |
-| [`visualisation.yml`](visualisation.yml)       | Python     | [8:00 and 11:00 every day](https://crontab.guru/#0_8,11_*_*_*) |                              |
+| Action name                                    | Language   | Scheduled at                                                   | Function                                           |
+|------------------------------------------------|------------|----------------------------------------------------------------|----------------------------------------------------|
+| [`ECDC.yml`](ECDC.yml)                         | R          | [12:00 every Thursday](https://crontab.guru/#0_12_*_*_4)       | Get recorded cases from ECDC                       |
+| [`JHU.yml`](JHU.yml)                           | Python     | [7:00 every day](https://crontab.guru/#0_7_*_*_*)              | Get recorded cases from JHU                        |
+| [`LANL.yml`](LANL.yml)                         | R          | [0:00 every day](https://crontab.guru/#0_0_*_*_*)              | Get forecasts produced by LANL                     |
+| [`check-truth.yml`](check-truth.yml)           | Python & R | [13:00 every day](https://crontab.guru/#0_13_*_*_*)            | Update and check truth data                        |
+| [`ensemble.yml`](ensemble.yml)                 | R          | [10:15 every Tuesday](https://crontab.guru/#15_10_*_*_2)       | Create weekly ensemble                             |
+| [`evaluation.yml`](evaluation.yml)             | R          | [10:00 every Sunday](https://crontab.guru/#0_10_*_*_0)         | Compute forecast scores                            |
+| [`reports-ensemble.yml`](reports-ensemble.yml) | R          | [10:45 every Tuesday](https://crontab.guru/#45_10_*_*_2)       | Compile ensemble report                            |
+| [`reports-eval.yml`](reports-eval.yml)         | R          | [9:00 every Sunday](https://crontab.guru/#0_9_*_*_0)           | Compile evaluation reports                         |
+| [`visualisation.yml`](visualisation.yml)       | Python     | [8:00 and 11:00 every day](https://crontab.guru/#0_8,11_*_*_*) | Prepare truth data and forecasts for visualisation |
 
 ## Submission checks
 


### PR DESCRIPTION
As a newcomer to the repo, I needed a single place that summarises the different actions, whether they are scheduled or run on a specific action, etc.

I left some blanks in the `Function` column because I'm not sure what is the function of some actions yet. Feel free to fill the blanks if you feel like it.

This could be part of the wiki instead but I think it makes sense to have them in the same place as the actions themselves. And it will be cloned with the repository if someone wanted to spin off another forecast hub from this repo.

You can preview the result here: https://github.com/Bisaloo/covid19-forecast-hub-europe/tree/actions-readme/.github/workflows