### PR TITLE
Use gh action to update submodules

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@
 | [`reports-eval.yml`](reports-eval.yml)         | R          | [9:00 every Sunday](https://crontab.guru/#0_9_*_*_0)           | Compile evaluation reports                         |
 | [`visualisation.yml`](visualisation.yml)       | Python     | [8:00 and 11:00 every day](https://crontab.guru/#0_8,11_*_*_*) | Prepare truth data and forecasts for visualisation |
 | [`zoltar-upload.yml`](zoltar-upload.yml)      | Python     | [7:00 every day](https://crontab.guru/#0_7_*_*_*)              | Upload modified data to [Zoltar](https://www.zoltardata.com/project/238) |
+| [`update-submodules.yml`](update-submodules.yml) |  | [7:00 every day](https://crontab.guru/#0_0_*_*_*)              | Update repository submodules to the head branch |
 
 ## Submission checks
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Commit
         env:
-          AUTH: ${{ secrets.GITHUBTOKEN }}
+          AUTH: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
           git config user.email "action@github.com"
           git config user.name "GitHub Action - update submodules"

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,0 +1,28 @@
+name: Update submodules
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+
+      - name: Commit
+        env:
+          AUTH: ${{ secrets.GITHUBTOKEN }}
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action - update submodules"
+          git add --all
+          git commit -m "Update submodules" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
I'm a bit concerned that the validation submodule in this repo is out of date, and is missing changes to the head branch of our [actual validations repo](https://github.com/epiforecasts/covid19-forecast-hub-europe-validations). 

This hasn't affected us yet - the PRs that go through validation directly use the head branch of the validation repo (not the submodule here). 

But this is an issue for Zoltar uploads (which relies on the submodule), as well as any user who wants to use the validation code in this central hub repo.

This action should set up to pull any submodule changes at midnight daily or on manual trigger.