### PR TITLE
`get_hub_config()` returns all settings by default

### DIFF
--- a/code/config_utils/get_hub_config.R
+++ b/code/config_utils/get_hub_config.R
@@ -1,3 +1,10 @@
 get_hub_config <- function(setting, config_file = "forecasthub.yml") {
-  yaml::read_yaml(here::here(config_file))[[setting]]
+  
+  if (missing(setting)) {
+    yaml::read_yaml(here::here(config_file))
+  }
+  
+  else {
+    yaml::read_yaml(here::here(config_file))[[setting]]
+  }
 }


### PR DESCRIPTION
Just to make it a little easier, adds a default to return all settings from `get_hub_config()` (i.e. the whole yaml).