### PR TITLE
trying to update ensemble options to be more robust

### DIFF
--- a/code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R
+++ b/code/ensemble/EuroCOVIDhub/create-weekly-ensemble.R
@@ -28,8 +28,6 @@ hub_ensemble <- run_ensemble(
   method = method,
   forecast_date = forecast_date,
   exclude_models = c(exclude_models, "EuroCOVIDhub-baseline"),
-  # Make explicit the hub default options
-  exclude_designated_other = TRUE,
   return_criteria = TRUE
 )
 

--- a/code/ensemble/methods/create-ensemble-relative-skill.R
+++ b/code/ensemble/methods/create-ensemble-relative-skill.R
@@ -37,8 +37,7 @@ create_ensemble_relative_skill <- function(forecasts,
                                            average = "mean",
                                            by_horizon = FALSE,
                                            return_criteria = FALSE,
-                                           verbose = FALSE,
-                                           ...) {
+                                           verbose = FALSE) {
 
 # Get evaluation ----------------------------------------------------------
   if (missing(evaluation_date)) {

--- a/code/ensemble/utils/run-ensemble.R
+++ b/code/ensemble/utils/run-ensemble.R
@@ -42,6 +42,7 @@ run_ensemble <- function(method = "mean",
                          exclude_models = NULL,
                          return_criteria = TRUE,
                          verbose = FALSE,
+                         exclude_designated_other = TRUE,
                          ...) {
 
   # Method ------------------------------------------------------------------
@@ -91,7 +92,7 @@ run_ensemble <- function(method = "mean",
   forecasts <- use_ensemble_criteria(forecasts = all_forecasts,
                                      exclude_models = exclude_models,
                                      return_criteria = return_criteria,
-                                     ...)
+                                     exclude_designated_other = exclude_designated_other)
 
   if (return_criteria) {
     criteria <- forecasts$criteria


### PR DESCRIPTION
Linked to [this discussion](https://github.com/epiforecasts/covid19-forecast-hub-europe/pull/602#discussion_r663084918). I think it's fine to set the default in `run_ensemble` - we want all the function that (re-)create ensembles to use this default anyway, and don't want to rely on remembering to set this explicitly, I think.