### PR TITLE
Link to ECDC data in `data-truth` README

### DIFF
--- a/data-truth/README.Rmd
+++ b/data-truth/README.Rmd
@@ -63,9 +63,9 @@ Open issues updated over the last eight weeks: from [JHU CSSEGISandData Github](
 
 ## Truth data
 
-We evaluate forecasts against [Johns Hopkins University data](https://github.com/CSSEGISandData/COVID-19), and we recommend using this dataset as the basis for forecasts.
+We evaluate forecasts of cases and deaths against [Johns Hopkins University data](https://github.com/CSSEGISandData/COVID-19), and we recommend using this dataset as the basis for forecasts.
 
-* Data are available to download from [JHU](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series), or from [our repository](https://github.com/epiforecasts/covid19-forecast-hub-europe/data-truth).
+* Daily numbers of cases and deaths are available to download from [JHU](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series), or from [our repository](https://github.com/epiforecasts/covid19-forecast-hub-europe/data-truth).
 * JHU also provide [country metadata](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/UID_ISO_FIPS_LookUp_Table.csv), including population counts and ISO-3 codes.
 
 Note there are some differences between the format of the JHU data and what we require in a forecast. Please check the [Wiki](https://github.com/epiforecasts/covid19-forecast-hub-europe/wiki/Targets-and-horizons#truth-data) for more on forecast formatting.

--- a/data-truth/README.Rmd
+++ b/data-truth/README.Rmd
@@ -59,3 +59,22 @@ knitr::kable(issues, escape = FALSE)
 
 ```
 Open issues updated over the last eight weeks: from [JHU CSSEGISandData Github](https://github.com/CSSEGISandData/COVID-19/)
+
+
+## Truth data
+
+We evaluate forecasts against [Johns Hopkins University data](https://github.com/CSSEGISandData/COVID-19), and we recommend using this dataset as the basis for forecasts.
+
+* Data are available to download from [JHU](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series), or from [our repository](https://github.com/epiforecasts/covid19-forecast-hub-europe/data-truth).
+* JHU also provide [country metadata](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/UID_ISO_FIPS_LookUp_Table.csv), including population counts and ISO-3 codes.
+
+Note there are some differences between the format of the JHU data and what we require in a forecast. Please check the [Wiki](https://github.com/epiforecasts/covid19-forecast-hub-europe/wiki/Targets-and-horizons#truth-data) for more on forecast formatting.
+
+#### Additional data sources
+We do not use or evaluate against these data, but the following might be useful for modelling targets:
+
+Data | Description | Source | Link
+--- | --- | --- | ---
+Vaccination | Number of vaccine doses distributed by manufacturers, number of first, second and unspecified doses administered | ECDC | [Data on COVID-19 vaccination in the EU/EEA](https://www.ecdc.europa.eu/en/publications-data/data-covid-19-vaccination-eu-eea)
+Variants of concern | Volume of COVID-19 sequencing, the number and percentage distribution of VOC for each country, week and variant submitted since 2020-W40  | ECDC | [Data on SARS-CoV-2 variants in the EU/EEA](https://www.ecdc.europa.eu/en/publications-data/data-virus-variants-covid-19-eueea)
+Testing |  Weekly testing rate and weekly test positivity | ECDC | [Data on testing for COVID-19 by week and country](https://www.ecdc.europa.eu/en/publications-data/covid-19-testing)

--- a/data-truth/README.md
+++ b/data-truth/README.md
@@ -3,13 +3,43 @@ European data status
 
 #### Potential issues in the JHU dataset
 
-As at 2021-07-04 13:23:17
+As at 2021-07-05 11:14:02
 
 | country | created    | updated    | issue                                                                     | message                                            | url                                                      |
-| :------ | :--------- | :--------- | :------------------------------------------------------------------------ | :------------------------------------------------- | :------------------------------------------------------- |
+|:--------|:-----------|:-----------|:--------------------------------------------------------------------------|:---------------------------------------------------|:---------------------------------------------------------|
 | france  | 2021-05-24 | 2021-06-28 | france negative cases may 20                                              | Hello all, Shortly, we will be merging in a PR th… | <https://github.com/CSSEGISandData/COVID-19/issues/4125> |
 | sweden  | 2021-06-21 | 2021-06-21 | sweden pauses reporting due to security breach                            | Hello all, The following (translated) message is … | <https://github.com/CSSEGISandData/COVID-19/issues/4264> |
 | spain   | 2021-06-11 | 2021-06-11 | catalonia, spain added backlogged cases (csse\_covid\_19\_daily\_reports) | Hi all, active cases in Catalonia have more than … | <https://github.com/CSSEGISandData/COVID-19/issues/4219> |
 
 Open issues updated over the last eight weeks: from [JHU CSSEGISandData
 Github](https://github.com/CSSEGISandData/COVID-19/)
+
+## Truth data
+
+We evaluate forecasts against [Johns Hopkins University
+data](https://github.com/CSSEGISandData/COVID-19), and we recommend
+using this dataset as the basis for forecasts.
+
+-   Data are available to download from
+    [JHU](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series),
+    or from [our
+    repository](https://github.com/epiforecasts/covid19-forecast-hub-europe/data-truth).
+-   JHU also provide [country
+    metadata](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/UID_ISO_FIPS_LookUp_Table.csv),
+    including population counts and ISO-3 codes.
+
+Note there are some differences between the format of the JHU data and
+what we require in a forecast. Please check the
+[Wiki](https://github.com/epiforecasts/covid19-forecast-hub-europe/wiki/Targets-and-horizons#truth-data)
+for more on forecast formatting.
+
+#### Additional data sources
+
+We do not use or evaluate against these data, but the following might be
+useful for modelling targets:
+
+| Data                | Description                                                                                                                              | Source | Link                                                                                                                            |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------|
+| Vaccination         | Number of vaccine doses distributed by manufacturers, number of first, second and unspecified doses administered                         | ECDC   | [Data on COVID-19 vaccination in the EU/EEA](https://www.ecdc.europa.eu/en/publications-data/data-covid-19-vaccination-eu-eea)  |
+| Variants of concern | Volume of COVID-19 sequencing, the number and percentage distribution of VOC for each country, week and variant submitted since 2020-W40 | ECDC   | [Data on SARS-CoV-2 variants in the EU/EEA](https://www.ecdc.europa.eu/en/publications-data/data-virus-variants-covid-19-eueea) |
+| Testing             | Weekly testing rate and weekly test positivity                                                                                           | ECDC   | [Data on testing for COVID-19 by week and country](https://www.ecdc.europa.eu/en/publications-data/covid-19-testing)            |

--- a/data-truth/README.md
+++ b/data-truth/README.md
@@ -3,7 +3,7 @@ European data status
 
 #### Potential issues in the JHU dataset
 
-As at 2021-07-05 11:14:02
+As at 2021-07-05 11:22:20
 
 | country | created    | updated    | issue                                                                     | message                                            | url                                                      |
 |:--------|:-----------|:-----------|:--------------------------------------------------------------------------|:---------------------------------------------------|:---------------------------------------------------------|
@@ -16,11 +16,11 @@ Github](https://github.com/CSSEGISandData/COVID-19/)
 
 ## Truth data
 
-We evaluate forecasts against [Johns Hopkins University
-data](https://github.com/CSSEGISandData/COVID-19), and we recommend
-using this dataset as the basis for forecasts.
+We evaluate forecasts of cases and deaths against [Johns Hopkins
+University data](https://github.com/CSSEGISandData/COVID-19), and we
+recommend using this dataset as the basis for forecasts.
 
--   Data are available to download from
+-   Daily numbers of cases and deaths are available to download from
     [JHU](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series),
     or from [our
     repository](https://github.com/epiforecasts/covid19-forecast-hub-europe/data-truth).


### PR DESCRIPTION
Adds text to the `data-truth` README Rmarkdown: 
- background on data sources (text taken from [wiki](https://github.com/epiforecasts/covid19-forecast-hub-europe/wiki/Targets-and-horizons#truth-data))
- links out to data on vaccines, VoCs, and testing from ECDC.