### PR TITLE
Add hospital data

### DIFF
--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -2,7 +2,7 @@ name: "ECDC"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 12 * * 4"
+    - cron: "0 12 * * *"
 
 jobs:
   get_ecdc:

--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -18,7 +18,7 @@ jobs:
       run: sudo apt-get install libudunits2-dev libcurl4-openssl-dev libgdal-dev
 
     - name: Install R dependencies
-      run: Rscript -e 'install.packages(c("here", "vroom", "eurostat", "dplyr", "countrycode", "tidyr", "ISOweek", "stringi"))'
+      run: Rscript -e 'install.packages(c("here", "readr", "dplyr", "tidyr", "ISOweek", "stringi"))'
 
     - name: ECDC Truth
       run: Rscript 'code/auto_download/ecdc_download.r'

--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -24,8 +24,6 @@ jobs:
       run: Rscript 'code/auto_download/ecdc_download.r'
 
     - name: Commit files
-      env:
-        AUTH: ${{ secrets.GITHUBTOKEN }}
       run: |
         git config user.email "action@github.com"
         git config user.name "GitHub Action - ECDC"
@@ -33,3 +31,9 @@ jobs:
         git commit -m "ECDC - daily"
         git push
         echo "pushed to github"
+
+      env:
+        AUTH: ${{secrets.GITHUB_TOKEN}}
+        DATA_USERNAME: ${{secrets.DATA_USERNAME}}
+        DATA_PASSWORD: ${{secrets.DATA_PASSWORD}}
+        DATA_URL: ${{secrets.DATA_URL}}

--- a/code/auto_download/ecdc_download.r
+++ b/code/auto_download/ecdc_download.r
@@ -1,8 +1,6 @@
 library("here")
-library("vroom")
-library("eurostat")
+library("readr")
 library("dplyr")
-library("countrycode")
 library("tidyr")
 library("ISOweek")
 library("stringi")
@@ -10,12 +8,10 @@ library("lubridate")
 
 cat("Downloading ECDC data\n")
 
-countries <- eurostat::eu_countries %>%
-  bind_rows(eurostat::efta_countries) %>%
-  rename(country = name, eurostat = code) %>%
-  mutate(country_code = countrycode(eurostat, "eurostat", "iso3c")) %>%
-  select(country_code)
+locations <- read_csv(here("data-locations", "locations_eu.csv")) %>%
+  select(location, location_name)
 
+# Case and death data
 ct <- "cc--cic---"
 
 ecdc_dir <- here::here("data-truth", "ECDC")
@@ -24,14 +20,14 @@ file_base <- "truth_ECDC-Incident"
 if (!dir.exists(ecdc_dir)) dir.create(ecdc_dir, recursive = TRUE)
 
 df <-
-  vroom::vroom("https://opendata.ecdc.europa.eu/covid19/nationalcasedeath/csv",
+  read_csv("https://opendata.ecdc.europa.eu/covid19/nationalcasedeath/csv",
                col_types = ct) %>%
-  inner_join(countries, by = "country_code") %>%
+  inner_join(locations, by = c("country" = "location_name")) %>%
   separate(year_week, c("year", "week"), sep = "-") %>%
   mutate(week_start = ISOweek2date(paste0(year, "-W", week, "-1"))) %>%
   mutate(indicator = stri_trans_totitle(indicator)) %>%
   select(week_start, indicator,
-         location = country_code, location_name = country,
+         location, location_name = country,
          value = weekly_count) %>%
   group_by(indicator) %>%
   group_walk(~ vroom_write(.x, delim = ",",
@@ -40,27 +36,23 @@ df <-
                                                    .y$indicator, ".csv"))))
 
 # Hospitalisation data
-# Get file
-data_filepath <- here("data-truth", "ECDC", 
+ecdc_hosp_filepath <- here("data-truth", "ECDC", 
                       "truth_ecdc-Incident Hospitalizations.csv") # covidHubUtils format
 
-R.utils::downloadFile(Sys.getenv("DATA_URL"), 
-                      data_filepath, 
+R.utils::downloadFile(Sys.getenv("DATA_URL"), # Uses set environment variables
+                      ecdc_hosp_filepath, 
                       username = Sys.getenv("DATA_USERNAME"), 
                       password = Sys.getenv("DATA_PASSWORD"),
                       skip = FALSE,
                       overwrite = TRUE)
 
-locations <- read_csv(here("data-locations", "locations_eu.csv")) %>%
-  select(location, location_name)
-
-# Format
 public_sources <- c("Country_Website", "Country_API", "Country_Github")
-ecdc <- vroom(data_filepath) %>%
+
+ecdc_hosp <- read_csv(ecdc_hosp_filepath) %>%
   filter(Indicator %in% c("New_Hospitalised") &
            Source %in% public_sources) %>%
   rename(location_name = CountryName) %>%
   mutate(target_variable = "inc hosp") %>%
   left_join(locations, by = "location_name") %>%
   select(date = Date, location, location_name, value = Value) %>%
-  write_csv(file = data_filepath, append = FALSE)
+  write_csv(file = ecdc_hosp_filepath, append = FALSE)


### PR DESCRIPTION
Adds daily hospital data from ECDC  to existing ECDC download script
- Data pulled from ECDC hosted source
- Access to source requires environment variables (/ github secrets)
- Filtered for data from a public source: one of Github API, Country API, Country website
- Formatted and saved in hub standard
- Data should be accessible using `covidHubUtils::load_truth()` - this just needs a quick PR into the package

Modifies Github action to support this:
- Data download run in existing github action
- Action updated to run daily
- Uses three additional secrets set in the github action

I also noticed some out of date code in the data download for ECDC cases and deaths (still using ISO-3 country codes, and we've found readr more reliable than vroom) so made those minor changes.