### PR TITLE
Run zoltar daily at 7am

### DIFF
--- a/.github/workflows/zoltar-upload.yml
+++ b/.github/workflows/zoltar-upload.yml
@@ -1,9 +1,9 @@
 name: Zoltar upload
 
 on:
-  workflow_dispatch #:
-  # schedule:
-  #  - cron: "0 7 * * *"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Zoltar uploads now work and we can update the GH action to run automatically. 

The workflow will run and show as successful even if nothing changed (it will only upload new files unless we direct otherwise, which would be a manual run). 

I've scheduled at 7am for no reason so whatever time is best.