### PR TITLE
Add `inc hosp` to hub config

### DIFF
--- a/forecasthub.yml
+++ b/forecasthub.yml
@@ -9,6 +9,7 @@ forecast_week_day: Monday
 target_variables:
   - inc case
   - inc death
+  - inc hosp
 forecast_type:
   point:
   quantiles: [0.01, 0.025, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 0.975, 0.99]


### PR DESCRIPTION
Adds `inc hosp` as a target variable.

This should work with https://github.com/epiforecasts/covid19-forecast-hub-europe-validations/pull/21 to mean that the validation accepts `{n} wk ahead inc hosp` as a valid target.