### PR TITLE
Add `validation` to `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ env
 
 # HTML-rendered version of READMEs
 README.html
+validation

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ env
 
 # HTML-rendered version of READMEs
 README.html
-validation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "validation"]
 	path = validation
 	url = https://github.com/epiforecasts/covid19-forecast-hub-europe-validations
+	ignore = all


### PR DESCRIPTION
I'd like to add the `validation` folder to gitignore. It's a submodule in any case so shouldn't be changed from the main repo, so this should prevent accidental edits (or out of date versions of the submodule) being pushed alongside other commits.