### PR TITLE
Add GitHub action to automatically rebase PR when a comment with '/rebase' is posted.

### DIFF
--- a/.github/workflows/rebase-comment.yml
+++ b/.github/workflows/rebase-comment.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && github.event.comment.author_association == 'MEMBER'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}


### PR DESCRIPTION
For security reasons, this is restricted to members of the epiforecasts organisation.

More generally, I prefer rebase to merging. It is a bit subjective but I find it makes the git history cleaner. 
For this reason, I also almost always 'rebase & merge' my PR instead of creating a merge commit: https://github.blog/2016-09-26-rebase-and-merge-pull-requests/
If the PR commit history is very messy and the change is relatively simple, I may opt for 'squash & merge'.