### PR TITLE
Add hospitalisations to reports

### DIFF
--- a/code/reports/rmdchunks/get-config-vars.Rmd
+++ b/code/reports/rmdchunks/get-config-vars.Rmd
@@ -10,7 +10,11 @@ countries_hub <- get_hub_config("forecast_locations", config_file = params$confi
 
 # FIXME: this breaks the fact that only changes in the config file should be 
 # necessary to add a new target
-target_variables <- c(Cases = "inc case", Deaths = "inc death")
+target_variables <- c(
+  Cases = "inc case", 
+  Deaths = "inc death",
+  Hospitalisations = "inc hosp"
+)
 ```
 
 ## {.unlisted .unnumbered}


### PR DESCRIPTION
I'm really not happy about this fix. The goal would be for everything to work when we change the config file, without having to keep a dictionary with nice labels for plots. The solution would be to use the nice labels directly in the raw data instead of abbreviated terms ('hosp') and to split 'inc case' into 'inc' and 'case'. Related: #708 and #796  

To do before it's ready to merge:

- [x] ~~Check why ensemble doesn't include hospitalisations and fix it.~~ As Seb suggested, we just needed to have a least 4 consecutive weeks of submission for this target.

