### PR TITLE
Fix warning logical of length > 1

### DIFF
--- a/code/reports/rmdchunks/ranking-table.Rmd
+++ b/code/reports/rmdchunks/ranking-table.Rmd
@@ -16,7 +16,7 @@ render <- JS(
 if (nrow(df) > 0) {
   df <- df %>%
     select(model, n, n_loc, rel_wis, rel_ae, cov_50, cov_95, bias)
-  if (all(df$n_loc == 1)) {
+  if (all(df$n_loc == 1L)) {
     df <- df %>%
       select(-n_loc)
   }

--- a/code/reports/rmdchunks/ranking-table.Rmd
+++ b/code/reports/rmdchunks/ranking-table.Rmd
@@ -16,7 +16,7 @@ render <- JS(
 if (nrow(df) > 0) {
   df <- df %>%
     select(model, n, n_loc, rel_wis, rel_ae, cov_50, cov_95, bias)
-  if (unique(df$n_loc) == 1) {
+  if (all(df$n_loc == 1)) {
     df <- df %>%
       select(-n_loc)
   }


### PR DESCRIPTION
If `n_loc` has multiple values, this will throw a warning. Additionally, it there are multiple values but 1 is one of them (e.g. 1, 2, 3), the `n_loc` column will be removed.

This PR implements what I think was the intended goal.