### PR TITLE
don't store continuous weeks in evaluation

### DIFF
--- a/code/reports/rmdchunks/score-forecasts.Rmd
+++ b/code/reports/rmdchunks/score-forecasts.Rmd
@@ -47,7 +47,8 @@ score_df <- score_df %>%
                                  "location"
                                )) %>%
   replace_na(list(continuous_weeks = 0)) %>%
-  filter(continuous_weeks >= restrict_weeks)
+  filter(continuous_weeks >= restrict_weeks) %>%
+  select(-continuous_weeks)
 
 ## number of forecasts
 num_fc <- score_df %>%


### PR DESCRIPTION
`scoringutils::compare_two_models` expects all columns except those being compared to be equal between models ([here](https://github.com/epiforecasts/scoringutils/blob/d09ff23e3cf9434606127ed145c315fedf9e1c40/R/pairwise-comparisons.R#L354)). Storing continuous weeks in the data frame before evaluating therefore creates a problem, as only those with the same number of continuous weeks of forecasts are being compared when calculating relative WIS/AE.

This fixes #823.