### PR TITLE
divide values by population size for plotting

### DIFF
--- a/code/reports/rmdchunks/plot-forecasts.Rmd
+++ b/code/reports/rmdchunks/plot-forecasts.Rmd
@@ -36,9 +36,11 @@ for (forecast_date in as.character(forecast_dates)) {
       filter_truth <- list(paste0("target_end_date > '", as.Date(forecast_date) - 7 * 10, "'"), 
                            paste0("target_end_date <= '", as.Date(forecast_date) + 7 * 4, "'"))
       filter_forecasts <- list(paste0("forecast_date == '", as.Date(forecast_date), "'"))
+      plot_data <- data %>%
+        mutate(across(c("true_value", "prediction"), ~ .x / population * 1e+5))
       
       plot <- scoringutils::plot_predictions(
-        data,
+        plot_data,
         x = "target_end_date",
         filter_both = filter_both,
         filter_truth = filter_truth,
@@ -49,7 +51,8 @@ for (forecast_date in as.character(forecast_dates)) {
         scales = "free_y") + 
         ggplot2::theme(legend.position = "bottom", 
                        strip.placement = "outside") + 
-        scale_y_continuous(labels = scales::comma) + 
+        scale_y_continuous("True and predicted values per week per 100,000",
+                           labels = scales::comma) +
         expand_limits(y = 0) +
         # Make sure negative values for cases/deaths are not displayed
         coord_cartesian(ylim = c(0, NA)) +


### PR DESCRIPTION
This brings the plot in line with the text in the reports - I think this works better than the absolute numbers but it does require people to pay attention to the y axis which can require scrolling down if there are a lot of plots:

![image](https://user-images.githubusercontent.com/1156307/130799457-372d0513-22b4-48be-a9a5-6f041c859f7d.png)

The alternative would be what we had before: divide by population for the ensemble reports (where it definitely makes sense for comparability) but keep absolute numbers for the country-by-country reports (where I feel less strongly), but that would require adjusting the text / legend / etc. in the code conditional on which report a plot is part of.

Fixes https://github.com/epiforecasts/covid19-forecast-hub-europe/issues/675.