### PR TITLE
Pull before attempting to push

### DIFF
--- a/.github/workflows/ECDC.yml
+++ b/.github/workflows/ECDC.yml
@@ -37,6 +37,7 @@ jobs:
         git config user.name "GitHub Action - ECDC"
         git add --all
         git commit -m "ECDC - daily" || echo "No changes to commit"
+        git pull --rebase
         git push
         echo "pushed to github"
       env:

--- a/.github/workflows/JHU.yml
+++ b/.github/workflows/JHU.yml
@@ -32,5 +32,6 @@ jobs:
         git config user.name "GitHub Action - JHU"
         git add --all
         git commit -m "JHU - daily"
+        git pull --rebase
         git push
         echo "pushed to github"

--- a/.github/workflows/LANL.yml
+++ b/.github/workflows/LANL.yml
@@ -35,4 +35,5 @@ jobs:
         git config user.name "GitHub Action - LANL"
         git add --all
         git commit -m "LANL - weekly" || echo "No changes to commit"
+        git pull --rebase
         git push

--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -35,5 +35,6 @@ jobs:
         git config user.name "GitHub Actions"
         git add --all
         git commit -m "Build baseline model"
+        git pull --rebase
         git push
         echo "pushed to github"

--- a/.github/workflows/check-truth.yml
+++ b/.github/workflows/check-truth.yml
@@ -52,5 +52,6 @@ jobs:
         git config user.name "GitHub Action - check truth"
         git add --all
         git commit -m "Check truth data"
+        git pull --rebase
         git push
         echo "pushed to github"

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -36,5 +36,6 @@ jobs:
         git config user.name "GitHub Action - mean ensemble"
         git add --all
         git commit -m "Build ensemble"
+        git pull --rebase
         git push
         echo "pushed to github"

--- a/.github/workflows/visualisation.yml
+++ b/.github/workflows/visualisation.yml
@@ -44,5 +44,6 @@ jobs:
         git config user.name "GitHub Action - Visualisation Update"
         git add --all
         git diff-index --quiet HEAD || git commit -m "Daily Visualisation update"
+        git pull --rebase
         git push
         echo "pushed to github"


### PR DESCRIPTION
This should hopefully limit the number of GH actions failure simply due to the fact that something was pushed between the moment when the action started to run and the moment when it tries to push the output.