### PR TITLE
bring back plot limits

### DIFF
--- a/.github/workflows/reports-eval.yml
+++ b/.github/workflows/reports-eval.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         install.packages(c("remotes", "here", "rmarkdown", "lubridate", "ggplot2", "dplyr", "DT", "knitr", "readr", "rlang"))
         remotes::install_github("reichlab/covidHubUtils")
-        remotes::install_github("epiforecasts/scoringutils")
+        remotes::install_github("epiforecasts/scoringutils@limit-viz")
         remotes::install_github("epiforecasts/EuroForecastHub")
       shell: Rscript {0}
 

--- a/code/reports/rmdchunks/plot-forecasts.Rmd
+++ b/code/reports/rmdchunks/plot-forecasts.Rmd
@@ -48,14 +48,17 @@ for (forecast_date in as.character(forecast_dates)) {
         facet_formula =  rlang::expr(~ !!facetting_var),
         ncol = n_cols,
         allow_truth_without_pred = FALSE,
+        zoom_multiple_data =
+          c(ymin = 0, ymax = 3),
+        expand_limits =
+          list(x =
+                 max(plot_data$target_end_date),
+               y = 0),
         scales = "free_y") + 
         ggplot2::theme(legend.position = "bottom", 
                        strip.placement = "outside") + 
         scale_y_continuous("True and predicted values per week per 100,000",
                            labels = scales::comma) +
-        expand_limits(y = 0) +
-        # Make sure negative values for cases/deaths are not displayed
-        coord_cartesian(ylim = c(0, NA)) +
         xlab("Week")
 
       if (is.null(plot)) {


### PR DESCRIPTION
Plot limits for forecasts that exceed the data by a lot were lost in the recent refactor. This returns them to all ensemble/evaluation plots.