### PR TITLE
Update `manual-exclusions.csv`

### DIFF
--- a/code/ensemble/EuroCOVIDhub/manual-exclusions.csv
+++ b/code/ensemble/EuroCOVIDhub/manual-exclusions.csv
@@ -2,3 +2,4 @@ forecast_date,model,reason_for_exclusion
 2021-03-22,MIMUW-StochSEIR,late submission
 2021-03-08,ITWW-county_repro,late submission
 2021-06-14,MIMUW-StochSEIR,late submission
+2021-10-04,ITWW-county_repro,late submission


### PR DESCRIPTION
#1021 is a late submission so could be added to the list of models to exclude from evaluation. 

On the other hand there's no question it was made in real-time (it's clearly [timestamped](https://github.com/KITmetricslab/covid19-forecast-hub-de/commit/10b8ede9d05d9a22193d818004e47f2672fce78f)). 

I'm not sure what the policy for the manual exclusion list should be: is exclusion based on 

- ensuring forecasts are real-time (no need to exclude correctly timestamped forecasts)

or 

- recreating the ensemble at-the-time (exclude anything not present at 11am Tuesday)? (This also means we should exclude the late submission https://github.com/epiforecasts/covid19-forecast-hub-europe/pull/993)

I have been assuming the first option although this hasn't been an issue before.