### PR TITLE
Exclude Switzerland from `inc hosp` forecasts this week

### DIFF
--- a/data-truth/anomalies/anomalies.csv
+++ b/data-truth/anomalies/anomalies.csv
@@ -12,3 +12,4 @@ target_end_date,target_variable,location,location_name,anomaly
 2021-06-12,inc case,ES,Spain,Historic cases added but not backdistributed in Catalonia
 2021-06-20,inc death,SE,Sweden,No data reported
 2021-06-20,inc case,SE,Sweden,No data reported
+2021-11-07,inc hosp,CH,Switzerland,Problem in data source

--- a/data-truth/anomalies/create-anomalies.R
+++ b/data-truth/anomalies/create-anomalies.R
@@ -25,7 +25,9 @@ anomalies <- tribble(
   "2021-06-12", "inc case", "ES", "Spain", "Historic cases added but not backdistributed in Catalonia",
   #
   "2021-06-20", "inc death", "SE", "Sweden", "No data reported",
-  "2021-06-20", "inc case", "SE", "Sweden", "No data reported"
+  "2021-06-20", "inc case", "SE", "Sweden", "No data reported",
+  #
+  "2021-11-07", "inc hosp", "CH", "Switzerland", "Problem in data source"
 ) %>%
   mutate(target_end_date = as.Date(target_end_date))
 


### PR DESCRIPTION
We have updated the data source as of today (#1196), so forecasts for Switzerland made for this week should be excluded from evaluation.